### PR TITLE
Fix typo in default runtimeprotect.yml

### DIFF
--- a/src/main/resources/config/runtimeprotect.yml
+++ b/src/main/resources/config/runtimeprotect.yml
@@ -49,7 +49,7 @@ domain_access_control:
   #
   # Examples:
   #
-  #     # Allow plugin "SomeGooglePlugin" to open connections on host "https://google.com" on default HTTPS port (434):
+  #     # Allow plugin "SomeGooglePlugin" to open connections on host "https://google.com" on default HTTPS port (443):
   #     - ALLOW PLUGIN=SomeGooglePlugin https://google.com PORT HTTPS
   #
   #     # Forbid all plugins to open connections on host "http://some-fishy-host.io" on port 12345:


### PR DESCRIPTION
Change HTTPS port in comments from 434 to 443, actual port substitution is correct. 